### PR TITLE
Fixed fillColumn not working

### DIFF
--- a/core/src/main/java/mc/obliviate/inventory/Gui.java
+++ b/core/src/main/java/mc/obliviate/inventory/Gui.java
@@ -189,7 +189,7 @@ public abstract class Gui implements InventoryHolder {
 	 */
 	public void fillColumn(GuiIcon item, @Nonnegative int column) {
 		Preconditions.checkArgument(column < 9);
-		for (int i = 0; i < 9; i++) {
+		for (int i = 0; i < (size/9); i++) {
 			this.addItem((i * 9 + column), item);
 		}
 	}


### PR DESCRIPTION
A column has less than 9 slots.
If the GUI has 5 rows, the column is only 5 slots high.