### PR TITLE
feature(configurable-gui): specify item slots using "-" and ","

### DIFF
--- a/configurablegui/src/main/java/mc/obliviate/inventory/configurable/util/GuiSerializer.java
+++ b/configurablegui/src/main/java/mc/obliviate/inventory/configurable/util/GuiSerializer.java
@@ -55,7 +55,7 @@ public class GuiSerializer {
 
     private static List<Integer> parseStringAsIntegerRange(String str) {
         final String[] slots = str.split("-");
-        if (slots.length != 2) new ArrayList<>();
+        if (slots.length != 2) return new ArrayList<>();
         int from, to;
 
         try {

--- a/configurablegui/src/main/java/mc/obliviate/inventory/configurable/util/GuiSerializer.java
+++ b/configurablegui/src/main/java/mc/obliviate/inventory/configurable/util/GuiSerializer.java
@@ -44,10 +44,11 @@ public class GuiSerializer {
 
     public static List<Integer> parseSlotString(String str) {
         if (str == null) return new ArrayList<>();
-        if (str.contains("-")) {
-            return parseStringAsIntegerRange(str);
-        } else if (str.contains(",")) {
+        str = str.replaceAll(" ", "");
+        if (str.contains(",")) {
             return parseStringAsIntegerList(str);
+        } else if (str.contains("-")) {
+            return parseStringAsIntegerRange(str);
         }
         return new ArrayList<>();
     }
@@ -77,7 +78,11 @@ public class GuiSerializer {
 
         for (final String slotText : slotStrings) {
             try {
-                pageSlots.add(Integer.parseInt(slotText));
+                if (slotText.contains("-")) {
+                    pageSlots.addAll(parseStringAsIntegerRange(slotText));
+                } else {
+                    pageSlots.add(Integer.parseInt(slotText));
+                }
             } catch (NumberFormatException ignore) {
             }
         }


### PR DESCRIPTION
Introduces the ability to specify item slots using a combination of hyphens ("-") and commas (","). Users can now input slot ranges such as "0-8,44-53".

Resolves #36 