### PR TITLE
Gradle version update and 1.20.6 support

### DIFF
--- a/configurablegui/build.gradle
+++ b/configurablegui/build.gradle
@@ -1,4 +1,4 @@
-var adventure = "4.13.1"
+var adventure = "4.17.0"
 dependencies {
     compileOnly project(':core')
     compileOnly 'org.spigotmc:spigot:1.16.4-R0.1-SNAPSHOT'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,4 +1,4 @@
-var adventure = "4.13.1"
+var adventure = "4.17.0"
 
 dependencies {
     compileOnly 'org.spigotmc:spigot:1.8.8-R0.1-SNAPSHOT'

--- a/core/src/main/java/mc/obliviate/inventory/util/NMSUtil.java
+++ b/core/src/main/java/mc/obliviate/inventory/util/NMSUtil.java
@@ -6,7 +6,6 @@ import org.bukkit.Bukkit;
 
 public class NMSUtil {
 
-    public static final String NMS = getNMS();
     public static final boolean IS_PAPER = isPaper();
     public static final boolean CAN_USE_COMPONENTS = ServerVersionController.isServerVersionAtLeast(ServerVersionController.V1_16) && IS_PAPER;
     public static final LegacyComponentSerializer LEGACY = LegacyComponentSerializer.builder()
@@ -15,26 +14,19 @@ public class NMSUtil {
     private static boolean isPaper() {
         try {
             Class.forName("com.destroystokyo.paper.PaperConfig");
-            Bukkit.getLogger().info("Paper detected");
             return true;
         } catch (ClassNotFoundException ignored) {
-            Bukkit.getLogger().info("Paper detected");
             return false;
         }
     }
 
-    private static String getNMS() {
-        final String version = Bukkit.getServer().getClass().getPackage().getName();
-        Bukkit.getLogger().info("version" + version);
-        return version.substring(version.lastIndexOf('.') + 1);
+    private static final String CRAFTBUKKIT_PACKAGE = Bukkit.getServer().getClass().getPackage().getName();
+    public static String cbClass(String clazz) {
+        return (CRAFTBUKKIT_PACKAGE + "." + clazz);
     }
 
     public static Class<?> getCraftBukkitClass(final String name) throws ClassNotFoundException {
-        Class cl = Class.forName("org.bukkit.craftbukkit." + NMS + "." + name);
-        Bukkit.getLogger().info(Bukkit.getServer().getClass().getPackage().getName());
-        Bukkit.getLogger().info("clye bak: " + cl);
-        Bukkit.getLogger().info("versiona bak: " + NMS);
-        return Class.forName("org.bukkit.craftbukkit." + NMS + "." + name);
+        return Class.forName(cbClass(name));
     }
 
 }

--- a/core/src/main/java/mc/obliviate/inventory/util/NMSUtil.java
+++ b/core/src/main/java/mc/obliviate/inventory/util/NMSUtil.java
@@ -31,7 +31,9 @@ public class NMSUtil {
 
     public static Class<?> getCraftBukkitClass(final String name) throws ClassNotFoundException {
         Class cl = Class.forName("org.bukkit.craftbukkit." + NMS + "." + name);
+        Bukkit.getLogger().info(Bukkit.getServer().getClass().getPackage().getName());
         Bukkit.getLogger().info("clye bak: " + cl);
+        Bukkit.getLogger().info("versiona bak: " + NMS);
         return Class.forName("org.bukkit.craftbukkit." + NMS + "." + name);
     }
 

--- a/core/src/main/java/mc/obliviate/inventory/util/NMSUtil.java
+++ b/core/src/main/java/mc/obliviate/inventory/util/NMSUtil.java
@@ -15,14 +15,17 @@ public class NMSUtil {
     private static boolean isPaper() {
         try {
             Class.forName("com.destroystokyo.paper.PaperConfig");
+            Bukkit.getLogger().info("Paper detected");
             return true;
         } catch (ClassNotFoundException ignored) {
+            Bukkit.getLogger().info("Paper detected");
             return false;
         }
     }
 
     private static String getNMS() {
         final String version = Bukkit.getServer().getClass().getPackage().getName();
+        Bukkit.getLogger().info("version" + version);
         return version.substring(version.lastIndexOf('.') + 1);
     }
 

--- a/core/src/main/java/mc/obliviate/inventory/util/NMSUtil.java
+++ b/core/src/main/java/mc/obliviate/inventory/util/NMSUtil.java
@@ -30,6 +30,8 @@ public class NMSUtil {
     }
 
     public static Class<?> getCraftBukkitClass(final String name) throws ClassNotFoundException {
+        Class cl = Class.forName("org.bukkit.craftbukkit." + NMS + "." + name);
+        Bukkit.getLogger().info("clye bak: " + cl);
         return Class.forName("org.bukkit.craftbukkit." + NMS + "." + name);
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/pagination/src/main/java/mc/obliviate/inventory/pagination/PaginationManager.java
+++ b/pagination/src/main/java/mc/obliviate/inventory/pagination/PaginationManager.java
@@ -174,7 +174,7 @@ public class PaginationManager {
      */
     public void clearAllItems() {
 
-        this.items = new LinkedList<>();
+        this.items.clear();
 
     }
 

--- a/pagination/src/main/java/mc/obliviate/inventory/pagination/PaginationManager.java
+++ b/pagination/src/main/java/mc/obliviate/inventory/pagination/PaginationManager.java
@@ -11,7 +11,7 @@ public class PaginationManager {
 
     private final Gui gui;
     private final LinkedList<Integer> slots = new LinkedList<>();
-    private LinkedList<Icon> items = new LinkedList<>();
+    private final LinkedList<Icon> items = new LinkedList<>();
     private int page;
 
     public PaginationManager(Gui gui) {

--- a/pagination/src/main/java/mc/obliviate/inventory/pagination/PaginationManager.java
+++ b/pagination/src/main/java/mc/obliviate/inventory/pagination/PaginationManager.java
@@ -11,7 +11,7 @@ public class PaginationManager {
 
     private final Gui gui;
     private final LinkedList<Integer> slots = new LinkedList<>();
-    private final LinkedList<Icon> items = new LinkedList<>();
+    private LinkedList<Icon> items = new LinkedList<>();
     private int page;
 
     public PaginationManager(Gui gui) {
@@ -164,7 +164,18 @@ public class PaginationManager {
      * Registers new itemstack to paginate. You don't have any limit to register.
      */
     public void addItem(Icon... icons) {
+
         this.items.addAll(Arrays.asList(icons));
+
+    }
+
+    /**
+     * Clear all items in pagination.
+     */
+    public void clearAllItems() {
+
+        this.items = new LinkedList<>();
+
     }
 
     /**


### PR DESCRIPTION
There was a name change in NMS packages in version 1.20.6.  That's why I updated it to the system recommended by the Paper community. It became working for 1.20.6. It also supports older versions. 
![image](https://github.com/hamza-cskn/obliviate-invs/assets/43517719/6544f747-ddd4-416b-a2aa-9a86389127e1)

I also updated the gradle version to 8.8
